### PR TITLE
Set self.edit to False on quit_nosave

### DIFF
--- a/editor/editor.py
+++ b/editor/editor.py
@@ -680,6 +680,7 @@ class Editor(object):
         return False
 
     def quit_nosave(self):
+        self.edit = False  # Used to detect that quit_nosave was triggered
         self.text = self.text_orig
         return False
 


### PR DESCRIPTION
Needed for tabview, to prevent the editor returning empty text (`self.text_orig = ""`) when overwrite-editing a cell.